### PR TITLE
Terraform Upgrade - (0.13 -> 0.15)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "aws_elasticache_replication_group" "redis" {
   maintenance_window            = var.maintenance_window
   snapshot_window               = var.snapshot_window
   snapshot_retention_limit      = var.snapshot_retention_limit
-  tags                          = merge(map("Name", format("tf-elasticache-%s-%s", var.name, lookup(data.aws_vpc.vpc.tags, "Name", ""))), var.tags)
+  tags                          = merge(tomap({"Name"=format("tf-elasticache-%s-%s", var.name, lookup(data.aws_vpc.vpc.tags, "Name", ""))}), var.tags)
   at_rest_encryption_enabled    = var.at_rest_encryption_enabled
 
   cluster_mode {

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aws_elasticache_parameter_group" "parameter_group" {
   # Strip the patch version from redis_version var
   family = "redis${replace(var.engine_version, "/\\.[\\d]+$/", "")}"
   dynamic "parameter" {
-    for_each = var.parameters
+    for_each = tolist(var.parameters)
     content {
       name  = parameter.value.name
       value = parameter.value.value
@@ -54,7 +54,7 @@ resource "aws_elasticache_parameter_group" "parameter_group" {
 
 resource "aws_elasticache_subnet_group" "subnet_group" {
   name       = replace(format("%.255s", lower(replace("tf-redis-${var.name}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")
-  subnet_ids = var.subnets
+  subnet_ids = tolist(var.subnets)
 }
 
 resource "aws_security_group" "security_group" {
@@ -68,12 +68,12 @@ resource "aws_security_group" "security_group" {
 }
 
 resource "aws_security_group_rule" "ingress" {
-  count                    = length(var.allowed_security_groups)
+  count                    = length(tolist(var.allowed_security_groups))
   type                     = "ingress"
   from_port                = var.port
   to_port                  = var.port
   protocol                 = "tcp"
-  source_security_group_id = element(var.allowed_security_groups, count.index)
+  source_security_group_id = element(tolist(var.allowed_security_groups), count.index)
   security_group_id        = aws_security_group.security_group.id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -17,13 +17,11 @@ variable "auto_minor_version_upgrade" {
 
 variable "allowed_cidr" {
   description = "A list of IP address CIDR's to allow access to."
-  type        = tolist([string])
   default     = []
 }
 
 variable "allowed_security_groups" {
   description = "A list of Security Group ID's to allow access to."
-  type        = tolist([string])
   default     = []
 }
 
@@ -66,7 +64,6 @@ variable "port" {
 }
 
 variable "subnets" {
-  type        = tolist([string])
   description = "List of VPC Subnet IDs for the cache subnet group"
 }
 
@@ -79,7 +76,6 @@ variable "engine_version" {
 
 variable "parameters" {
   description = "additional parameters modified in parameter group"
-  type        = list(tomap({any}))
   default     = []
 }
 
@@ -103,7 +99,6 @@ variable "snapshot_retention_limit" {
 
 variable "tags" {
   description = "Tags for redis nodes"
-  type        = tomap({string})
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -17,13 +17,13 @@ variable "auto_minor_version_upgrade" {
 
 variable "allowed_cidr" {
   description = "A list of IP address CIDR's to allow access to."
-  type        = list(string)
+  type        = tolist([string])
   default     = []
 }
 
 variable "allowed_security_groups" {
   description = "A list of Security Group ID's to allow access to."
-  type        = list(string)
+  type        = tolist([string])
   default     = []
 }
 
@@ -66,7 +66,7 @@ variable "port" {
 }
 
 variable "subnets" {
-  type        = list(string)
+  type        = tolist([string])
   description = "List of VPC Subnet IDs for the cache subnet group"
 }
 
@@ -74,12 +74,12 @@ variable "subnets" {
 variable "engine_version" {
   description = "Redis version to use"
   type        = string
-  default     = "5.0.5"
+  default     = "6.x"
 }
 
 variable "parameters" {
   description = "additional parameters modified in parameter group"
-  type        = list(map(any))
+  type        = list(tomap({any}))
   default     = []
 }
 
@@ -103,7 +103,7 @@ variable "snapshot_retention_limit" {
 
 variable "tags" {
   description = "Tags for redis nodes"
-  type        = map(string)
+  type        = tomap({string})
   default     = {}
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -7,5 +7,5 @@ terraform {
       source = "hashicorp/random"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.15"
 }


### PR DESCRIPTION
Made syntax changes based on terraform recommended for the `list` and `map` functions that have been deprecated. Something to note is that i tried to retain these defaults within `variables.tf`. However, using `any` or `string` within was not working and seemed to be specific to the deprecated function `list` and `map`. 